### PR TITLE
Use devon_rex_base instead of buildpack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM quay.io/actcat/buildpack_base:latest
-
-MAINTAINER pocke <p.ck.t22@gmail.com>
+FROM quay.io/actcat/devon_rex_base:1.0.4
 
 # Install pyenv
 RUN curl -L https://raw.githubusercontent.com/yyuu/pyenv-installer/master/bin/pyenv-installer | bash
@@ -9,9 +7,7 @@ ENV PYENV_ROOT /root/.pyenv
 ENV PATH $PYENV_ROOT/shims:$PYENV_ROOT/bin:$PATH
 
 # Install python 2 and 3
-RUN pyenv install 2.7.10 \
-  && pyenv install 3.5.0 \
+RUN pyenv install 2.7.13 \
+  && pyenv install 3.6.2 \
   && pyenv rehash        \
-  && pyenv global 3.5.0
-
-RUN apt-get update -y
+  && pyenv global 3.6.2

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+build:
+	docker build -t quay.io/actcat/devon_rex_python:dev .


### PR DESCRIPTION
- Use devon_rex_base
- Update Python versions
- Do not run apt-get update